### PR TITLE
Clarify prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ sudo chmod +x /usr/bin/chromedriver
 ```
 The Chrome web driver needs chrome to be installed to function and is version specific
 If you do not have Chrome installed use the following to install
-'''
+```
 sudo dnf install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
-'''
+```
 Following that you may need to reinstall the appropriate version of the chrome driver
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Installation/setup
 ## 1. Clone repo and change to directory
 ```
@@ -15,7 +16,12 @@ sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver 
 sudo chmod +x /usr/bin/chromedriver 
 ```
-
+The Chrome web driver needs chrome to be installed to function and is version specific
+If you do not have Chrome installed use the following to install
+'''
+sudo dnf install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+'''
+Following that you may need to reinstall the appropriate version of the chrome driver
 
 
 # Scraping Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pandas
 selenium
 BeautifulSoup4
+Google Chrome
+Google ChromeDriver of a similar version
+external access to https://brickseek.com/walmart-inventory-checker/


### PR DESCRIPTION
The Chrome so Web Driver needs to have chrome installed I added that to the prereqs and a note about the dependency between the version of the web driver and the version of Chrome in the Readme. 

@ddroder 
This is a practical example use case for page scraping.  If you call out the contribution of Brickseek.com and describe the need to query based on multiple sku's in a radius you could use this to show an example for somebody sorting through how that works. 
Or pass the SKU list as an input and make a universal SKU finder for Brickseek.
